### PR TITLE
Changing caching to decorator

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,6 +7,8 @@ class Config(object):
     TESTING = False
     KIND = 'zenoss'
 
+    #CACHE_DEFAULT_TIMEOUT = 500
+
 
 class ProductionConfig(Config):
 

--- a/dcsqa/app.py
+++ b/dcsqa/app.py
@@ -9,6 +9,7 @@ from criteria import criteria_blueprint
 from raw import raw_blueprint
 from result import result_blueprint
 from auth import auth
+from cache import cache
 
 app = Flask(__name__)
 
@@ -22,7 +23,7 @@ def _get_url_prefix(request_type, version='v1'):
 
 def create_app(app_name='dcsqa', config='config.DevelopmentConfig'):
     app.config.from_object(config)
-    app.cache = Cache(app) 
+    cache.init_app(app)
 
     # register blueprint for each restful entry
     # http://flask.pocoo.org/docs/0.10/blueprints/

--- a/dcsqa/cache.py
+++ b/dcsqa/cache.py
@@ -1,0 +1,4 @@
+from flask.ext.cache import Cache
+
+# Refer to - https://github.com/thadeusb/flask-cache/issues/84
+cache = Cache()

--- a/dcsqa/dao/table.py
+++ b/dcsqa/dao/table.py
@@ -28,6 +28,7 @@ class DataTable(object):
             KeyConditionExpression=Key('TicketKey').eq(ticket_key)
         )
         if response['Count'] > 0:
+            self.logger.debug(response['Items'])
             return response['Items']
         else:
             self.logger.warn("there are no record TicketKey=%s in %s" % (ticket_key, self.table.name))
@@ -40,6 +41,7 @@ class DataTable(object):
         
         if response['Count'] > 0:
             items = response['Items']
+            self.logger.debug(items[0])
             #not return array
             return items[0]
         else:

--- a/dcsqa/raw.py
+++ b/dcsqa/raw.py
@@ -82,7 +82,7 @@ def set_raw_by_ticketkey_host():
     dao = DataTable(region_name=current_app.config['DYNAMODB_REGION'],
                     table_name=current_app.config['RAW_TABLE'],
                     logger=current_app.logger)
-    result = dao.save(raw)
+    dao.save(raw)
 
     # 5.
     cache.delete_memoized(get_all_raw)


### PR DESCRIPTION
Hi @hidetosaito,

Here is the example for using cache.memoize() decorator in [FlaskCache](https://pythonhosted.org/Flask-Cache/#flask.ext.cache.Cache.delete_memoized).
cache.py is for avoiding circular import as https://github.com/thadeusb/flask-cache/issues/84 suggests.
Please kindly help review and if everything is okay. I'll merge it to the master branch.

Thank you very much for your patience and continuous guidance :-D

Regards,
Chloe
